### PR TITLE
Set manage-domain-zero=true to re-enable autoballoon of domain 0

### DIFF
--- a/lib/squeeze.ml
+++ b/lib/squeeze.ml
@@ -50,6 +50,8 @@ let error fmt =
        D.error "%s" x
     ) fmt
 
+let manage_domain_zero = ref false
+
 (** Per-domain data *)
 type domain = {
 	domid: int;

--- a/scripts/squeezed.conf
+++ b/scripts/squeezed.conf
@@ -9,3 +9,6 @@ disable-logging-for=http
 # Host memory will be re-examined and possibly re-balanced
 # every balance-check-interval
 balance-check-interval=10
+
+# Set to true if you want domain zero to be automatically ballooned
+# manage-domain-zero=false

--- a/src/squeeze_xen.ml
+++ b/src/squeeze_xen.ml
@@ -414,8 +414,13 @@ let make_host ~verbose ~xc =
 	(* We cannot query simultaneously the host memory info and the domain memory info. Furthermore
 	   the call to domain_getinfolist is not atomic but comprised of many hypercall invocations. *)
 
-	(* We are excluding dom0, so it will never be ballooned down. *)
-	let domain_infolist = List.filter (fun di -> di.Xenctrl.domid > 0) (Xenctrl.domain_getinfolist xc 0) in
+	let domain_infolist = Xenctrl.domain_getinfolist xc 0 in
+	(* Check if we are managing dom0 *)
+	let domain_infolist =
+		if !Squeeze.manage_domain_zero
+		then domain_infolist
+		else List.filter (fun di -> di.Xenctrl.domid > 0) domain_infolist in
+
 	(*
 		For the host free memory we sum the free pages and the pages needing
 		scrubbing: we don't want to adjust targets simply because the scrubber
@@ -522,11 +527,12 @@ let make_host ~verbose ~xc =
 						  } ]
 					end
 				with
-				| Xs_protocol.Enoent _ ->
+				| Xs_protocol.Enoent path ->
+debug "ENOENT %s" path;
 				    (* useful debug message is printed by the Domain.read* functions *)
 				    []
 				|  e ->
-					if verbose 
+					if verbose || true
 					then debug "Skipping domid %d: %s"
 						di.Xenctrl.domid (Printexc.to_string e);
 					[]

--- a/src/squeezed.ml
+++ b/src/squeezed.ml
@@ -24,6 +24,7 @@ let balance_check_interval = ref 10.
 
 let options = [
 	"balance-check-interval", Arg.Set_float balance_check_interval, (fun () -> string_of_float !balance_check_interval), "Seconds between memory balancing attempts";
+	"manage-domain-zero", Arg.Bool (fun b -> Squeeze.manage_domain_zero := b), (fun () -> string_of_bool !Squeeze.manage_domain_zero), "Manage domain zero";
 ]
 
 let _ = 


### PR DESCRIPTION
This is particularly useful in configurations where domain 0 owns
all the memory and it must be ballooned out to start any VMs.

Signed-off-by: David Scott dave.scott@eu.citrix.com
