### PR TITLE
Optionally manage dom0

### DIFF
--- a/lib/squeeze.ml
+++ b/lib/squeeze.ml
@@ -51,6 +51,9 @@ let error fmt =
     ) fmt
 
 let manage_domain_zero = ref false
+let gib = Int64.(mul 1024L (mul 1024L 1024L))
+let domain_zero_dynamic_min : int64 ref = ref gib  (* 1 GiB minimum for safety *)
+let domain_zero_dynamic_max : int64 option ref = ref None (* static max *)
 
 (** Per-domain data *)
 type domain = {

--- a/scripts/squeezed.conf
+++ b/scripts/squeezed.conf
@@ -12,3 +12,12 @@ balance-check-interval=10
 
 # Set to true if you want domain zero to be automatically ballooned
 # manage-domain-zero=false
+
+# If managing domain zero, we won't balloon lower than this value
+# domain-zero-dynamic-min = 1073741824
+
+# If managing domain zero, we won't balloon higher than this value
+# 'auto' means use all available memory (where 'available' means
+# available to domain 0, possibly constrained by the xen commandline)
+# domain-zero-dynamic-max = auto
+

--- a/src/squeeze_xen.ml
+++ b/src/squeeze_xen.ml
@@ -626,4 +626,30 @@ let balance_memory ~xc =
 (** Return true if the host memory is currently unbalanced and needs rebalancing *)
 let is_host_memory_unbalanced ~xc = 
   Squeeze.is_host_memory_unbalanced (io ~verbose:false ~xc)
-  
+
+(* If we want to manage domain 0, we must write the policy settings to xenstore *)
+let configure_domain_zero () =
+  (* Domain.write_noexn will drop the write if the directory doesn't exist
+     we make sure it already exists. *)
+  Client.with_xs (get_client ()) (fun xs ->
+    Client.mkdir xs "/local/domain/0"
+  );
+  Xenctrl.with_intf
+    (fun xc ->
+      Domain.write_noexn xc 0 _dynamic_min (Int64.to_string (Memory.kib_of_bytes_used !Squeeze.domain_zero_dynamic_min));
+      let dynamic_max = match !Squeeze.domain_zero_dynamic_max with
+      | Some x -> Memory.kib_of_bytes_used x
+      | None ->
+        (* If this is the first time we've started after boot then we
+           can use the current domain 0 total_pages value. Otherwise we
+           continue to use the version already in xenstore. *)
+        if Domain.exists xc 0 _dynamic_max
+        then Int64.of_string (Domain.read xc 0 _dynamic_max)
+        else
+          let di = Xenctrl.domain_getinfo xc 0 in
+          Xenctrl.pages_to_kib (Int64.of_nativeint di.Xenctrl.total_memory_pages) in
+      Domain.write_noexn xc 0 _dynamic_max (Int64.to_string dynamic_max);
+      if not (Domain.exists xc 0 _target)
+      then Domain.write_noexn xc 0 _target (Int64.to_string dynamic_max);
+      Domain.write_noexn xc 0 _feature_balloon "1"
+  )

--- a/src/squeezed.ml
+++ b/src/squeezed.ml
@@ -25,6 +25,8 @@ let balance_check_interval = ref 10.
 let options = [
 	"balance-check-interval", Arg.Set_float balance_check_interval, (fun () -> string_of_float !balance_check_interval), "Seconds between memory balancing attempts";
 	"manage-domain-zero", Arg.Bool (fun b -> Squeeze.manage_domain_zero := b), (fun () -> string_of_bool !Squeeze.manage_domain_zero), "Manage domain zero";
+	"domain-zero-dynamic-min", Arg.String (fun x -> Squeeze.domain_zero_dynamic_min := Int64.of_string x), (fun () -> Int64.to_string !Squeeze.domain_zero_dynamic_min), "Always leave domain 0 with at least this much memory";
+	"domain-zero-dynamic-max", Arg.String (fun x -> Squeeze.domain_zero_dynamic_max := if x = "auto" then None else Some (Int64.of_string x)), (fun () -> match !Squeeze.domain_zero_dynamic_max with None -> "using the static-max value" | Some x -> Int64.to_string x), "Maximum memory to allow domain 0";
 ]
 
 let _ = 
@@ -47,6 +49,7 @@ let _ =
 
 	Memory_server.start_balance_thread balance_check_interval;
 	Squeeze_xen.Domain.start_watch_xenstore_thread ();
+	if !Squeeze.manage_domain_zero then Squeeze_xen.configure_domain_zero ();
 
 	Xcp_service.serve_forever server
 


### PR DESCRIPTION
By default squeezed ignores domain 0 -- this hasn't changed.

However if you set
  manage-domain-zero = true
in the config file or on the command-line, it will regain its old domain 0 managing powers.
