### PR TITLE
CA-155178: Remove squeeze_xen cache if domain disappear

### DIFF
--- a/src/squeeze_xen.ml
+++ b/src/squeeze_xen.ml
@@ -86,6 +86,22 @@ module Domain = struct
 			  Hashtbl.remove cache domid;
 			  None
 
+  let remove_gone_domains_cache xc =
+	  let current_domains = Xenctrl.domain_getinfolist xc 0 in
+	  Mutex.execute m
+	  (fun () ->
+			try
+				let alive_domids = List.map (fun d -> d.Xenctrl.domid) current_domains in
+  				let known_domids = Hashtbl.fold (fun k _ acc -> k :: acc) cache [] in
+  				let gone_domids = set_difference known_domids alive_domids in
+  				List.iter
+				(fun d ->
+					debug "Remove domid %d in cache" d;
+					Hashtbl.remove cache d
+				) gone_domids
+  			with _ -> ()
+	  )
+
   let _introduceDomain = "@introduceDomain"
   let _releaseDomain = "@releaseDomain"
 
@@ -550,6 +566,7 @@ let make_host ~verbose ~xc =
 	(* Externally-visible side-effects. It's a bit ugly to include these here: *)
 	update_cooperative_table host;
 	update_cooperative_flags cnx;
+	Domain.remove_gone_domains_cache xc;
 
 	(* It's always safe to _decrease_ a domain's maxmem towards target. This catches the case
 	   where a toolstack creates a domain with maxmem = static_max and target < static_max (eg


### PR DESCRIPTION
Cleanup disappear domains in domain make to avoid dirty domain cache

Signed-off-by: Cheng Zhang <cheng.zhang@citrix.com>