### PR TITLE
CA-169891: Fix FD leak when reading sysfs

### DIFF
--- a/src/memory_server.ml
+++ b/src/memory_server.ml
@@ -178,22 +178,12 @@ let parse_sysfs_balloon () =
 		_requested_target;
 		_low_mem_balloon;
 		_high_mem_balloon] in
-	let string_of_file filename =
-		let results = ref [] in
-		let ic = open_in filename in
-		try
-			while true do
-				let line = input_line ic in
-				results := line :: !results
-			done;
-			"" (* this will never occur... *)
-		with End_of_file -> String.concat "" (List.rev !results) in
 	let r = Re_str.regexp "[ \t\n]+" in
 	let strip line = match Re_str.split_delim r line with
 		| x :: _ -> x
 		| [] -> "" in
 	List.map (fun key ->
-		let s = string_of_file (sysfs_stem ^ key) in
+		let s = Unixext.string_of_file (sysfs_stem ^ key) in
 		key, Int64.of_string (strip s)
 	) keys
 


### PR DESCRIPTION
I have tested this by running this on a trunk-ring3 build and checking that the symptom disappears. As a testcase, I restart Xapi which makes a couple of RPCs to squeezed (`get_host_reserved_memory` and `get_domain_zero_policy`) and this was seen to leak 4 FDs at a time before the change and zero after...

Before change:

    # ls /proc/$(pidof squeezed)/fd | wc -l
    85
    # service xapi restart
    Restarting xapi (via systemctl):                           [  OK  ]
    # ls /proc/$(pidof squeezed)/fd | wc -l
    89

After change:

    # ls /proc/$(pidof squeezed)/fd | wc -l
    9
    # service xapi restart
    Restarting xapi (via systemctl):                           [  OK  ]
    # ls /proc/$(pidof squeezed)/fd | wc -l
    9

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>