### PR TITLE
CA-115733: Mark a stuck VM and do not retry ballooning them

### DIFF
--- a/lib/squeeze.ml
+++ b/lib/squeeze.ml
@@ -60,6 +60,8 @@ type domain = {
 	domid: int;
 	(** true if the domain has ballooning capability i.e. is not paused etc. *)
 	can_balloon: bool;
+	(** true if the domain has been declared stuck by squeezed *)
+	is_stuck: bool;
 	(** admin-imposed lower-limit on the balloon target *)
 	dynamic_min_kib: int64;
 	(** current balloon target requested by the system *)
@@ -75,10 +77,11 @@ type domain = {
 }
 
 let domain_make
-	domid can_balloon dynamic_min_kib target_kib dynamic_max_kib memory_actual_kib memory_max_kib inaccuracy_kib =
+	domid can_balloon is_stuck dynamic_min_kib target_kib dynamic_max_kib memory_actual_kib memory_max_kib inaccuracy_kib =
 	{
 		domid = domid;
 		can_balloon = can_balloon;
+		is_stuck = is_stuck;
 		dynamic_min_kib = dynamic_min_kib;
 		target_kib = target_kib;
 		dynamic_max_kib = dynamic_max_kib;
@@ -92,6 +95,7 @@ let domain_to_string_pairs (x: domain) =
 	[
 		"domid", i x.domid;
 		"can_balloon", string_of_bool x.can_balloon;
+		"is_stuck", string_of_bool x.is_stuck;
 		"dynamic_min_kib", i64 x.dynamic_min_kib;
 		"target_kib", i64 x.target_kib;
 		"dynamic_max_kib", i64 x.dynamic_max_kib;
@@ -180,7 +184,7 @@ let has_hit_target inaccuracy_kib memory_actual_kib target_kib =
 let short_string_of_domain domain = 
   Printf.sprintf "%d T%Ld A%Ld M%Ld %s%s" domain.domid
     domain.target_kib domain.memory_actual_kib domain.memory_max_kib
-    (if domain.can_balloon then "B" else "?")
+    (if (domain.can_balloon && not domain.is_stuck) then "B" else if (domain.can_balloon && domain.is_stuck) then "X" else "?")
     (string_of_direction (direction_of_actual domain.inaccuracy_kib domain.memory_actual_kib domain.target_kib))
 
 (** Generic code to guesstimate if a balloon driver is stuck *)
@@ -226,7 +230,7 @@ module Stuckness_monitor = struct
 				 let makingprogress = (delta_actual > 0L && direction = Some Down) || (delta_actual < 0L && direction = Some Up) in
 				 (* We keep track of the last time we were makingprogress. If we are makingprogress now 
 					then we are not stuck. *)
-				 if makingprogress then begin
+				 if makingprogress && not state.stuck then begin
 				   state.last_makingprogress_time <- now;
 				   state.stuck <- false;
 				 end;
@@ -234,7 +238,10 @@ module Stuckness_monitor = struct
 					assume_balloon_driver_stuck_after then declare this domain stuck. *)
 				 let request = direction <> None in (* ie target <> actual *)
 				 if request && (now -. state.last_makingprogress_time > assume_balloon_driver_stuck_after)
-				 then state.stuck <- true;
+				 then begin 
+				 	debug "domain = %d is marked stuck" domain.domid;
+				 	state.stuck <- true;
+					end;
 			)
 			host.domains;
 		(* Clear out dead domains just in case someone keeps *)
@@ -338,7 +345,7 @@ module Squeezer = struct
 		Stuckness_monitor.update x.stuckness host now;
 		let active_domains = 
 		  List.filter (fun domain ->
-				 domain.can_balloon
+				 domain.can_balloon && not domain.is_stuck
 				 && (Stuckness_monitor.domid_is_active x.stuckness domain.domid now))
 			host.domains in
 		let non_active_domids = List.map (fun d -> d.domid) (set_difference host.domains active_domains) in
@@ -478,6 +485,7 @@ type io = {
 	execute_action: action -> unit;
 	wait: float -> unit;
 	gettimeofday: unit -> float;
+	declare_domain_stuck: int -> unit;
 	
 	target_host_free_mem_kib: int64;
 	free_memory_tolerance_kib: int64;
@@ -536,6 +544,8 @@ let change_host_free_memory ?fistpoints io required_mem_kib success_condition =
     let debug_string = String.concat "; " (host_debug_string :: (List.map (fun domain -> short_string_of_domain domain ^ (new_target_direction domain)) host.domains)) in
     debug "%s" debug_string;
     
+    List.iter (io.declare_domain_stuck ) declared_inactive_domids;
+
 	(* For each domid, decide what maxmem should be *)
 	let maxmems = IntMap.mapi
 	  (fun domid domain ->
@@ -587,6 +597,7 @@ let free_memory_range ?fistpoints io min_kib max_kib =
   (* First compute the 'ideal' amount of free memory based on the proportional allocation policy *)
   let domain = { domid = -1;
 		 can_balloon = true;
+		 is_stuck = false;
 		 dynamic_min_kib = min_kib; dynamic_max_kib = max_kib;
 		 target_kib = min_kib;
 		 memory_actual_kib = 0L;

--- a/test/squeeze_test.ml
+++ b/test/squeeze_test.ml
@@ -179,9 +179,9 @@ let scenario_a = {
 	should_succeed = true;
 	scenario_domains = [
 		new idealised_vm_with_limit
-			(domain_make 0 true 1000L 1500L 2000L 1500L 1500L 4L) 100L 1250L;
+			(domain_make 0 true false 1000L 1500L 2000L 1500L 1500L 4L) 100L 1250L;
 		new intermittently_stuck_vm
-			(domain_make 1 true 2500L 3500L 4500L 3500L 3500L 4L) 500L 0.25;
+			(domain_make 1 true false 2500L 3500L 4500L 3500L 3500L 4L) 500L 0.25;
 	];
 	host_free_mem_kib = 0L;
 	required_mem_kib = 1000L;
@@ -195,9 +195,9 @@ let scenario_b = {
 	should_succeed = true;
 	scenario_domains = [
 		new intermittently_stuck_vm
-			(domain_make 1 true 500L 3500L 4500L 3500L 3500L 4L) 100L 3.;
+			(domain_make 1 true false 500L 3500L 4500L 3500L 3500L 4L) 100L 3.;
 		new intermittently_stuck_vm
-			(domain_make 0 true 500L 1500L 2500L 1500L 1500L 4L) 100L 1.5;
+			(domain_make 0 true false 500L 1500L 2500L 1500L 1500L 4L) 100L 1.5;
 	];
 	host_free_mem_kib = 0L;
 	required_mem_kib = 1000L;
@@ -210,8 +210,8 @@ let scenario_c = {
 		freed";
 	should_succeed = false;
 	scenario_domains = [
-		new idealised_vm (domain_make 0 true 1000L 1500L 2000L 1500L 1500L 0L) 100L;
-		new idealised_vm (domain_make 1 true 2000L 2500L 3000L 2500L 2500L 0L) 100L;
+		new idealised_vm (domain_make 0 true false 1000L 1500L 2000L 1500L 1500L 0L) 100L;
+		new idealised_vm (domain_make 1 true false 2000L 2500L 3000L 2500L 2500L 0L) 100L;
 	];
 	host_free_mem_kib = 0L;
 	required_mem_kib = 1500L;
@@ -225,9 +225,9 @@ let scenario_d = {
 	should_succeed = false;
 	scenario_domains = [
 		new idealised_vm
-			(domain_make 0 true 1000L 1500L 2000L 1500L 1500L 0L) 100L;
+			(domain_make 0 true false 1000L 1500L 2000L 1500L 1500L 0L) 100L;
 		new idealised_vm_with_limit
-			(domain_make 1 true 2000L 2500L 3000L 2500L 2500L 0L) 100L 2250L;
+			(domain_make 1 true false 2000L 2500L 3000L 2500L 2500L 0L) 100L 2250L;
 	];
 	host_free_mem_kib = 0L;
 	required_mem_kib = 1000L;
@@ -244,10 +244,10 @@ let scenario_e = {
 	scenario_domains = [
 		(* The stuck domain is using more than it should be if the memory was freed and everything balanced *)
 		new stuck_vm
-			(domain_make 0 true (*min*)5000L (*target*)7000L (*max*)7000L (*actual*)7000L 7000L 0L);
+			(domain_make 0 true false (*min*)5000L (*target*)7000L (*max*)7000L (*actual*)7000L 7000L 0L);
 		(* The working domain is using less than it should be if the memory was freed and everything balanced *)
 		new idealised_vm
-			(domain_make 1 true (*min*)5000L (*target*)6000L (*max*)11000L (*actual*)6000L 6000L 0L) 100L;
+			(domain_make 1 true false (*min*)5000L (*target*)6000L (*max*)11000L (*actual*)6000L 6000L 0L) 100L;
 
 	];
 	host_free_mem_kib = 0L;
@@ -290,9 +290,9 @@ let scenario_h = {
 	should_succeed = true;
 	scenario_domains = [
 		new idealised_vm_with_upper_limit
-			(domain_make 0 true 1000L 1500L 2000L 1500L 1500L 4L) 100L 1500L;
+			(domain_make 0 true false 1000L 1500L 2000L 1500L 1500L 4L) 100L 1500L;
 		new idealised_vm
-			(domain_make 1 true 1000L 1500L 2000L 1500L 1500L 4L) 100L; (* this one can take up the slack *)
+			(domain_make 1 true false 1000L 1500L 2000L 1500L 1500L 4L) 100L; (* this one can take up the slack *)
 	];
 	host_free_mem_kib = 1000L;
 	required_mem_kib = 0L;
@@ -415,6 +415,7 @@ let simulate scenario =
     execute_action = execute_action;
     target_host_free_mem_kib = scenario.required_mem_kib;
     free_memory_tolerance_kib = 0L;
+    declare_domain_stuck = (fun domid -> ());
   } in
 
   finally


### PR DESCRIPTION
When VMs that are stuck are retried for ballooing in the subsequent iterations
it results in other working VMs memory oscillating between couple of values

Signed-off-by: Koushik Chakravarty <koushik.chakravarty@citrix.com>