### PR TITLE
CA-195542: Consider all domains as active for memory reservation.

### DIFF
--- a/src/squeeze_xen.ml
+++ b/src/squeeze_xen.ml
@@ -649,7 +649,7 @@ let change_host_free_memory ~xc required_mem_kib success_condition =
 
 let free_memory ~xc required_mem_kib = 
   let io = io ~verbose:true ~xc in
-  Squeeze.change_host_free_memory io (required_mem_kib +* io.Squeeze.target_host_free_mem_kib) (fun x -> x >= (required_mem_kib +* io.Squeeze.target_host_free_mem_kib))
+  Squeeze.change_host_free_memory ~consider_all_domains_as_active:true io (required_mem_kib +* io.Squeeze.target_host_free_mem_kib) (fun x -> x >= (required_mem_kib +* io.Squeeze.target_host_free_mem_kib))
 
 let free_memory_range ~xc min_kib max_kib =
   let io = io ~verbose:true ~xc in


### PR DESCRIPTION
1) Whenever asked by xenopsd for memory reservation consider all
domains as active irrespective domains marked as stuck.
2) Domains marked as stuck can't be consider by squeezed main loop
to balloon up/down but can be considered to balloon whenever asked
by xenopsd for creating new domains.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>