### PR TITLE
CA-258652/SCTX-2565: Record initial host free memory

### DIFF
--- a/src/squeezed.ml
+++ b/src/squeezed.ml
@@ -46,6 +46,8 @@ let _ =
 	(* NB Initialise the xenstore connection after daemonising, otherwise
 	   we lose our connection *)
 
+	Memory_server.record_boot_time_host_free_memory ();
+
 	let rpc_server = Thread.create Xcp_service.serve_forever server in
 
 	Memory_server.start_balance_thread balance_check_interval;

--- a/src/squeezed_state.ml
+++ b/src/squeezed_state.ml
@@ -21,6 +21,8 @@ let ( |> ) a b = b a
 
 let _service = "squeezed"
 
+let initial_host_free_memory_file = "/var/run/nonpersistent/xapi/boot_time_memory"
+
 let listdir path = try List.filter (fun x -> x <> "") (Client.immediate (get_client ()) (fun xs -> Client.directory xs path)) with Xs_protocol.Enoent _ -> []
 let xs_read path = try Client.immediate (get_client ()) (fun xs -> Client.read xs path) with Xs_protocol.Enoent _ as e -> begin debug "xenstsore-read %s returned ENOENT" path; raise e end
 let xs_read_option path = try Some (Client.immediate (get_client ()) (fun xs -> Client.read xs path)) with Xs_protocol.Enoent _ -> None


### PR DESCRIPTION
Prior to this fix, xapi was responsible for calculating the
initial host free memory and recording it in a file in dom0.
This caused an issue on hosts with a CVM; xapi would exclude
the CVM memory in its calculation but it would include it in
subsequent reboots; this happened because, on firstboot, the
CVM is started after xapi, but on reboots it starts before.

squeezed always starts before the CVM and xapi, so the
calculation is moved here to ensure predictable behaviour.

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>