### PR TITLE
fix off by 1 MiB in Domain.get_maxmem

### DIFF
--- a/src/squeeze_xen.ml
+++ b/src/squeeze_xen.ml
@@ -82,10 +82,9 @@ module Domain = struct
     else
       try
         let di = Xenctrl.domain_getinfo xc domid in
-        let maxmem = Xenctrl.pages_to_kib (Int64.of_nativeint di.Xenctrl.max_memory_pages) in
         let d = { path = Printf.sprintf "/local/domain/%d" domid;
                   hvm = di.Xenctrl.hvm_guest;
-                  maxmem = maxmem;
+                  maxmem = maxmem_of_dominfo di;
                   keys = Hashtbl.create 10 } in
         Hashtbl.replace cache domid d;
         Some d

--- a/src/squeeze_xen.ml
+++ b/src/squeeze_xen.ml
@@ -68,6 +68,12 @@ module Domain = struct
   let cache = Hashtbl.create 10
 
   let m = Mutex.create ()
+
+  let maxmem_of_dominfo di =
+    let memory_max_kib = Xenctrl.pages_to_kib (Int64.of_nativeint di.Xenctrl.max_memory_pages) in
+    (* Misc other stuff appears in max_memory_pages *)
+    max 0L (memory_max_kib -* (xen_max_offset_kib di.Xenctrl.hvm_guest))
+
   (* get_per_domain can return None if the domain is deleted by
      	 someone else while we are processing some other event handlers *)
   let get_per_domain xc domid =
@@ -450,9 +456,7 @@ let make_host ~verbose ~xc =
                   with _ -> 0L
                 else 0L in
               (* dom0 is special for some reason *)
-              let memory_max_kib = if di.Xenctrl.domid = 0 then 0L else Xenctrl.pages_to_kib (Int64.of_nativeint di.Xenctrl.max_memory_pages) in
-              (* Misc other stuff appears in max_memory_pages *)
-              let memory_max_kib = max 0L (memory_max_kib -* (xen_max_offset_kib di.Xenctrl.hvm_guest)) in
+              let memory_max_kib = if di.Xenctrl.domid = 0 then 0L else Domain.maxmem_of_dominfo di in
               let can_balloon = Domain.get_feature_balloon cnx di.Xenctrl.domid in
               let has_guest_agent = Domain.get_guest_agent cnx di.Xenctrl.domid in
               let has_booted = can_balloon || has_guest_agent in


### PR DESCRIPTION
   In CA-263119 we had all HVM VMs declared as uncooperative, and squeezed failing to meet its target. The domains were not really uncooperative (if you manually wrote a lower target in xenstore they adjusted their memory usage), but the target was not actually achievable because maximum memory was set lower than the target by about 1 MiB. From the VM's point of view it seemed it has done as much ballooning as possible.
    Squeezed accounted for the HVM offset when writing maxmem, but not when reading maxmem, which caused the safety check (of only writing targets <= maxmem) not work properly.
  
Without this change I got into 2 different failure modes:

- 0 free memory on host, unable to start VMs, due to xenopsd refusing to even wait for more memory to become available (assuming [it'll never happen](https://github.com/xapi-project/xenopsd/blob/2705115bf02e20dce82598417052b73738b9f6d2/xc/domain.ml#L158))

- too much free memory on the host and the memory amongst the VMs unbalanced (some having 265 MiB, some 864 MiB, whereas they all have dynamic-min=256MiB and dynamic-max=1024MiB) and squeezed assuming none of them are capable of making progress and not even adjusting the `target` value

After the change I got this on the same 2 hosts when I replace `squeezed`, and the memory of all VMs is evenly balanced:
`Oct 25 16:17:17 localhost squeezed[9316]: [126.94] Success: Host free memory = 9216 KiB`
`Oct 25 16:31:58 localhost squeezed[22314]: [999.05] Success: Host free memory = 9216 KiB`

Waiting for a build to complete to rerun the original testcase.