### PR TITLE
maintenance: use rpclib instead of rpc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: c
-services: docker
-install:
-    - wget https://raw.githubusercontent.com/xenserver/xenserver-build-env/master/utils/travis-build-repo.sh
-script: bash travis-build-repo.sh
-sudo: true
+sudo: required
+service: docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+script: bash -ex .travis-docker.sh
 env:
-    global:
-        - REPO_PACKAGE_NAME=squeezed
-        - REPO_CONFIGURE_CMD=true
-        - REPO_BUILD_CMD=make
-        - REPO_TEST_CMD='make test'
+  global:
+    - OCAML_VERSION="4.07"
+    - DISTRO="debian-unstable"
+    - PINS="xapi-squeezed:."
+    - PACKAGE="xapi-squeezed"
+    - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"

--- a/xapi-squeezed.opam
+++ b/xapi-squeezed.opam
@@ -20,7 +20,7 @@ depends: [
   "cohttp" {>= "0.11.0"}
   "uri"
   "re"
-  "rpc"
+  "rpclib"
   "xapi-idl"
   "xenstore"
   "xenstore_transport"


### PR DESCRIPTION
ppx_deriving_rpc is not needed as the library only uses rpc for the server