### PR TITLE
CA-327822: account for memory-offset during set_maxmem

### DIFF
--- a/src/squeeze_xen.ml
+++ b/src/squeeze_xen.ml
@@ -377,7 +377,8 @@ module Domain = struct
 
   (** Set a domain's maxmem. Don't throw an exception if the domain has been destroyed *)
   let set_maxmem_noexn cnx domid target_kib =
-    let maxmem_kib = xen_max_offset_kib (get_domain_type cnx domid) +* target_kib in
+    let offset_kib : int64 = try get_memory_offset cnx domid with _ -> 0L in
+    let maxmem_kib = xen_max_offset_kib (get_domain_type cnx domid) +* target_kib +* offset_kib in
     set_maxmem_noexn cnx domid maxmem_kib
 
   (** Return true if feature_balloon has been advertised *)


### PR DESCRIPTION
The addition of PV-shim mode exposed the following issue. For a pv-in-pvh
guest, memory-offset value will include the whole amount of xen-shim
memory (see CA-327265), which can be quite large (e.g. 68MB for a 4GB RAM
guest). This leads to a situation when:

    * Initial domain's memory: 4G + 68M
        * xen-shim memory: 68M
        * PV kernel memory: 4G
    * memory-offset: 68M
    * memory/target: 4G
    * set_maxmem hypercall: 4G

This leads to a problem during ballooning up: Xen (L0) will forbid
the domain to have more than 4G of memory and the following situation
would be observed:

    * Domain's memory: 4G
        * xen-shim memory: 68M
        * PV kernel memory: 4G - 68M

Which makes a balloon driver to believe it hasn't yet reached the target
of 4GB and to constantly ask Xen to give more pages. Meanwhile squeezed
would consider that the domain couldn't reach its target in time.

Fix this situation by adding the memory-offset value into set_maxmem.

Signed-off-by: Sergey Dyasli <sergey.dyasli@citrix.com>