### PR TITLE
CA-335725: Calculate a constant boot time host free memory

### DIFF
--- a/lib/squeeze.ml
+++ b/lib/squeeze.ml
@@ -54,6 +54,8 @@ let manage_domain_zero = ref false
 let gib = Int64.(mul 1024L (mul 1024L 1024L))
 let domain_zero_dynamic_min : int64 ref = ref gib  (* 1 GiB minimum for safety *)
 let domain_zero_dynamic_max : int64 option ref = ref None (* static max *)
+let boot_time_host_free_memory_constant_count : int ref = ref 10
+let boot_time_host_free_memory_check_interval : float ref = ref 1.0
 
 (** Per-domain data *)
 type domain = {

--- a/src/squeezed.ml
+++ b/src/squeezed.ml
@@ -27,6 +27,8 @@ let options = [
   "manage-domain-zero", Arg.Bool (fun b -> Squeeze.manage_domain_zero := b), (fun () -> string_of_bool !Squeeze.manage_domain_zero), "Manage domain zero";
   "domain-zero-dynamic-min", Arg.String (fun x -> Squeeze.domain_zero_dynamic_min := Int64.of_string x), (fun () -> Int64.to_string !Squeeze.domain_zero_dynamic_min), "Always leave domain 0 with at least this much memory";
   "domain-zero-dynamic-max", Arg.String (fun x -> Squeeze.domain_zero_dynamic_max := if x = "auto" then None else Some (Int64.of_string x)), (fun () -> match !Squeeze.domain_zero_dynamic_max with None -> "using the static-max value" | Some x -> Int64.to_string x), "Maximum memory to allow domain 0";
+  "boot-time-host-free-memory-constant-count", Arg.String (fun x -> Squeeze.boot_time_host_free_memory_constant_count := int_of_string x), (fun () -> Printf.sprintf "%d" !Squeeze.boot_time_host_free_memory_constant_count), "Boot time host memory is constant until geting this count of same result of free memory";
+  "boot-time-host-free-memory-check-interval ", Arg.String (fun x -> Squeeze.boot_time_host_free_memory_check_interval := float_of_string x), (fun () -> Printf.sprintf "%.2f" !Squeeze.boot_time_host_free_memory_check_interval), "Seconds between boot time host free memory check";
 ]
 
 
@@ -71,7 +73,7 @@ let _ =
   (* NB Initialise the xenstore connection after daemonising, otherwise
      we lose our connection *)
 
-  Memory_server.record_boot_time_host_free_memory ();
+  let _ = Thread.create Memory_server.record_boot_time_host_free_memory () in
 
   let rpc_server = Thread.create Xcp_service.serve_forever server in
 


### PR DESCRIPTION
Free memory of the host is changing when boot and it takes a while to be
constant.

To get a conatant value of the boot time host free memory to make xapi able to
calculate the accurate free memory of the host.

1. Add 2 paramters to configure 1) how many same check results mean the free memory
is constant. 2) interval of checks
2. Run the free memory checker in a thread because it usually takes dozens of
seconds.
3. The `get_host_initial_free_memory` API will be blocked until the free memory
is calculated.

Signed-off-by: Yang Qian <yang.qian@citrix.com>