### PR TITLE
Use shared Travis configuration to fix the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: c
-sudo: required
 service: docker
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+install:
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+  - wget https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env
+  - source xs-opam-ci.env
 script: bash -ex .travis-docker.sh
 env:
   global:
-    - OCAML_VERSION="4.07"
-    - DISTRO="debian-unstable"
     - PINS="xapi-squeezed:."
+  jobs:
     - PACKAGE="xapi-squeezed"
-    - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"


### PR DESCRIPTION
We are using OCaml 4.08.1 now, lets control this from a central place in
xs-opam.
