### PR TITLE
CA-335725: Update the tolerance of free memory difference

### DIFF
--- a/src/memory_server.ml
+++ b/src/memory_server.ml
@@ -299,7 +299,7 @@ let calculate_boot_time_host_free_memory () =
     Int64.mul 1024L boot_time_host_free_kib
 
 let calc_constant_boot_time_host_free_memory constant_count_min interval =
-  let tolerance = 10L in
+  let tolerance = 1048576L in
   debug "Check boot time host free memory: constant-count-min=%d check-interval=%f(seconds)" constant_count_min interval;
   let rec calc_constant last constant_count =
     let free_memory = calculate_boot_time_host_free_memory () in


### PR DESCRIPTION
The free memory unit is byte and 10 byte is too small for a suitable tolerance
so update it to 1 MiB.

Signed-off-by: Yang Qian <yang.qian@citrix.com>